### PR TITLE
feat(directUrl): use new `directUrl` for CLI commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://..."
+ACCELERATE_URL="prisma://accelerate.prisma-data.net..."

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -2,9 +2,7 @@ import { PrismaClient } from "@prisma/client/edge";
 import useAccelerate from "@prisma/extension-accelerate";
 
 function makePrisma() {
-  return new PrismaClient({
-    datasources: { db: { url: process.env.ACCELERATE_URL } },
-  }).$extends(useAccelerate);
+  return new PrismaClient().$extends(useAccelerate);
 }
 
 const globalForPrisma = global as unknown as {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,8 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url       = env("ACCELERATE_URL")
+  directUrl = env("DATABASE_URL")
 }
 
 model Link {


### PR DESCRIPTION
4.10.0 introduced the new datasource property `directUrl`, which makes it easier for Prisma Client and CLI to use different connection strings.