### PR TITLE
fix: .sort() should sort numbers (not strings)

### DIFF
--- a/pages/api/stream.ts
+++ b/pages/api/stream.ts
@@ -92,7 +92,7 @@ async function p50(
       cb(duration);
     }
   }
-  return durations.sort().at(Math.floor(durations.length * 0.5)) ?? NaN;
+  return durations.sort((a, b) => a - b).at(Math.floor(durations.length * 0.5)) ?? NaN;
 }
 
 async function time(fn: () => Promise<unknown>): Promise<number> {

--- a/pages/api/time.ts
+++ b/pages/api/time.ts
@@ -42,7 +42,7 @@ async function p50(
       durations.push(duration);
     }
   }
-  return durations.sort().at(Math.floor(durations.length * 0.5)) ?? NaN;
+  return durations.sort((a, b) => a - b).at(Math.floor(durations.length * 0.5)) ?? NaN;
 }
 
 async function time(fn: () => Promise<unknown>): Promise<number> {


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort The default sort order is ascending, built upon converting the elements into strings, then comparing their sequences of UTF-16 code units values.

Example:
For this run the p50 was 448 but since the sorting was not done like expected p50 returned 2943 instead.

Given this array of numbers: `[ 2943, 224, 448 ]`

Default sort:
`[ 224, 2943, 448 ]`

Fix:
`[ 224, 448, 2943 ]`
